### PR TITLE
Reduce server memory usage by ~85MB RSS / ~100MB heap

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var t0 = Date.now();
 
 var bibref = require('./lib/bibref');
+delete bibref.raw;
 
 var app = module.exports = require("express")();
 

--- a/lib/bibref.js
+++ b/lib/bibref.js
@@ -78,7 +78,7 @@ function _copyProps(src, dest) {
 }
 
 function _cloneJSON(obj) {
-    return JSON.parse(JSON.stringify(obj));
+    return structuredClone(obj);
 }
 
 function Bibref() {


### PR DESCRIPTION
## Summary

- Delete `bibref.raw` in `index.js` after startup — the server never reads it after `doneAddingRefs()`, but it holds the pre-expansion copy of all parsed refs (~22MB of JSON, ~60MB in heap objects) for the lifetime of the process. Tests and `scripts/*` load `bibref` in their own processes and are unaffected.
- Replace `JSON.parse(JSON.stringify(x))` in `_cloneJSON` with the native `structuredClone`. Avoids allocating a ~22MB intermediate JSON string during `expandRefs` startup and is faster. Safe on Node ≥17 (`engines.node` requires ≥20.14).

## Measurements

Measured against `refs/` at HEAD, using `process.memoryUsage()` before and after loading `lib/bibref`:

| metric     | before  | after   | delta   |
|------------|---------|---------|---------|
| RSS        | 433 MB  | 349 MB  | ~85 MB  |
| heapUsed   | 186 MB  | 86 MB   | ~100 MB |

## Test plan

- [x] `npm test` — 366,276 passing, 0 failing (unchanged vs. baseline on `main`)