### PR TITLE
Update repository references from tobie to specinfra

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -86,13 +86,13 @@
                             <svg class="icon icon-cloud-download"><use xlink:href="#icon-cloud-download"></use></svg>
                             Use
                         </h4>
-                        <p>Fetch normalized JSON data through the <a href="https://github.com/tobie/specref/blob/master/README.md#api">Web API</a> or rely on existing integration in <a href="https://github.com/tabatkins/bikeshed">spec-authoring</a> <a href="https://github.com/w3c/respec/">tools</a>.</p>
+                        <p>Fetch normalized JSON data through the <a href="https://github.com/specinfra/specref/blob/main/README.md#api">Web API</a> or rely on existing integration in <a href="https://github.com/tabatkins/bikeshed">spec-authoring</a> <a href="https://github.com/w3c/respec/">tools</a>.</p>
                         
                         <h4>
                             <svg class="icon icon-github3"><use xlink:href="#icon-github3"></use></svg>
                             Contribute
                         </h4>
-                        <p>Add new references and update existing ones on <a href="https://github.com/tobie/specref">GitHub</a>.</p>
+                        <p>Add new references and update existing ones on <a href="https://github.com/specinfra/specref">GitHub</a>.</p>
                         
                         <h4>
                             <svg class="icon icon-cogs"><use xlink:href="#icon-cogs"></use></svg>

--- a/docs/js/search.js
+++ b/docs/js/search.js
@@ -204,7 +204,7 @@ function metadata(refcount, timeago) {
         refcount.textContent = formatRefCount(data.refCount);
     });
 
-    getJSON("https://api.github.com/repos/tobie/specref/commits", { path: "refs", per_page: 1 }).then(function(data) {
+    getJSON("https://api.github.com/repos/specinfra/specref/commits", { path: "refs", per_page: 1 }).then(function(data) {
         timeago.innerHTML = " (last one <a href=\"" + data[0].html_url + "\">" + formatTime(new Date - Date.parse(data[0].commit.committer.date)) + "</a>)";
     });
 }


### PR DESCRIPTION
## Summary
Updates all repository references to point to the new `specinfra` organization on GitHub, reflecting the project's ownership change from the original `tobie` account.

## Key Changes
- Updated GitHub repository URL in documentation from `tobie/specref` to `specinfra/specref`
- Updated API documentation link to reference the new repository's `main` branch instead of `master`
- Updated GitHub API endpoint in search.js to fetch commits from the new `specinfra/specref` repository

## Details
These changes ensure that:
- Users are directed to the correct repository for contributions and issue reporting
- API documentation links point to the current repository location
- The metadata display showing last commit information fetches from the correct repository

https://claude.ai/code/session_01SscfAcqfsEb3tpdxeGMKwY