### PR TITLE
Add a /health endpoint for Clever Cloud's health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Specref API
   * [Obsoleted references](#obsoleted-references)
   * [CORS](#cors)
   * [Examples](#examples)
+* [Deployment](#deployment)
 * [Contributing](#contributing)
 * [Licenses](#licenses)
 
@@ -220,6 +221,14 @@ Some examples should help:
     GET https://api.specref.org/bibrefs?refs=SVG,REX,DAHUT&callback=yourFunctionName
 
 If you need to find a reference ID (for either bibliographic or cross-references) you need to look for it on [specref.org](http://specref.org).
+
+## Deployment
+
+The API is hosted on [Clever Cloud](https://www.clever-cloud.com/). The server exposes a lightweight health check endpoint at `/health` which always responds with `200 OK` and `{ "status": "ok" }`, without touching the reference database.
+
+Clever Cloud must be configured to poll this endpoint (rather than `/`, which returns a 404) so that it can tell whether the instance is up during deployment and while it is running, and only restarts it when it actually stops responding. Set the following environment variable on the Clever Cloud application:
+
+    CC_HEALTH_CHECK_PATH=/health
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,18 @@ if (process.env.NODE_ENV == "dev" || process.env.NODE_ENV == "development") {
     errorhandlerOptions.showStack = true;
 }
 app.enable("etag");
+
+// Health check. Registered before the IP filter, compression and body
+// parsing middleware so that it stays cheap and can never be blocked or
+// slowed down by them. Clever Cloud polls this path (see
+// CC_HEALTH_CHECK_PATH in the README) both during deployment and while
+// the app is running, and restarts the instance if it fails to respond
+// with a 2xx status code.
+app.get('/health', function (req, res) {
+    res.setHeader("Cache-Control", "no-store");
+    res.status(200).json({ status: "ok" });
+});
+
 var bannedIPs = [
 	// Palo Alto Networks bot
 	"34.96.130.0/24", "34.77.162.0/24", "34.86.35.0/24"
@@ -130,8 +142,10 @@ app.get('/xrefs', function (req, res, next) {
     res.status(410).jsonp({ message: "xrefs are no longer supported." });
 });
 
-var port = process.env.PORT || 5000;
-app.listen(port, function () {
-    console.log("Express server listening on port %d in %s mode", port, app.settings.env);
-    console.log("App started in", (Date.now() - t0) + "ms.");
-});
+if (require.main === module) {
+    var port = process.env.PORT || 5000;
+    app.listen(port, function () {
+        console.log("Express server listening on port %d in %s mode", port, app.settings.env);
+        console.log("App started in", (Date.now() - t0) + "ms.");
+    });
+}

--- a/test/health.js
+++ b/test/health.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+var http = require('http');
+var app = require('../index');
+
+suite('Health check', function() {
+    var server, port;
+
+    suiteSetup(function(done) {
+        server = app.listen(0, function() {
+            port = server.address().port;
+            done();
+        });
+    });
+
+    suiteTeardown(function(done) {
+        server.close(done);
+    });
+
+    function request(method, path, cb) {
+        http.request({ method: method, port: port, path: path }, function(res) {
+            var body = "";
+            res.setEncoding("utf8");
+            res.on("data", function(chunk) { body += chunk; });
+            res.on("end", function() { cb(res, body); });
+        }).end();
+    }
+
+    test("GET /health responds with 200 and an ok status.", function(done) {
+        request("GET", "/health", function(res, body) {
+            assert.strictEqual(res.statusCode, 200);
+            assert.strictEqual(res.headers["cache-control"], "no-store");
+            assert.deepStrictEqual(JSON.parse(body), { status: "ok" });
+            done();
+        });
+    });
+
+    test("HEAD /health responds with 200.", function(done) {
+        request("HEAD", "/health", function(res) {
+            assert.strictEqual(res.statusCode, 200);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Clever Cloud polls the app to decide whether an instance is up, and
restarts it when the check fails. The app had no cheap route to point it
at: `/` returns a 404 and the other routes go through the IP filter and
serve the full reference database.

Add a `/health` route, registered ahead of the IP filter, compression and
body-parsing middleware, that always answers 200 with `{"status":"ok"}`
and `Cache-Control: no-store`. Only call `app.listen()` when index.js is
the entry point so the app can be required from tests, and add a test
that starts the app on an ephemeral port and checks GET and HEAD on
`/health`. Document `CC_HEALTH_CHECK_PATH=/health` in the README.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A1V24eqH7XY6zPvSxDG1XU