### PR TITLE
Replace BCP47 alias with a concrete non-alias entry

### DIFF
--- a/refs/biblio.json
+++ b/refs/biblio.json
@@ -243,7 +243,24 @@
         "aliasOf": "rfc6557"
     },
     "BCP47": {
-        "aliasOf": "rfc5646"
+		"href": "https://www.rfc-editor.org/info/bcp47",
+		"title": "Tags for Identifying Languages",
+		"authors": [
+		    "Addison Phillips",
+		    "Mark Davis"
+		],
+		"rawDate": "2009-09",
+		"status": "Best Current Practice",
+		"seeAlso": [
+		   "RFC5646",
+		   "RFC4647"
+		],
+		"publisher": "IETF",
+		"obsoletes": [
+		   "RFC1766",
+		   "RFC3066",
+		   "RFC4646"
+		]
     },
     "BERNERS-LEE98": {
         "aliasOf": "RDF-NOT"


### PR DESCRIPTION
BCP47 consists of two RFCs, 5646 and 4647, and is the preferred, stable reference for language tags. This change replaces the current alias entry with a proper reference. BCP47 is widely references, particularly in the I18N space. (`npm test` runs cleans)

Fixes #688